### PR TITLE
A bunch of features and fixes (contains Wizzel1's scroll speed commits) [details in comment]

### DIFF
--- a/lib/src/scroll_state.dart
+++ b/lib/src/scroll_state.dart
@@ -50,7 +50,6 @@ class ScrollState with ChangeNotifier {
           bool shouldLock = lastLock != null ? (lastLock == currPos) : (posPixels != currPos + deltaDelta && 
             (currPos != controller.position.maxScrollExtent || currDelta < 0) && 
             (currPos != controller.position.minScrollExtent || currDelta > 0));
-          //bool shouldLock = lastLock != null ? (lastLock == currPos) : (currPos != posPixels);
           if (!outOfBounds && shouldLock) {
             controller.jumpTo(posPixels);
             lastLock = posPixels;

--- a/lib/src/scroll_state.dart
+++ b/lib/src/scroll_state.dart
@@ -30,7 +30,7 @@ class ScrollState with ChangeNotifier {
   }
 
   void handleDesktopScroll(
-      PointerSignalEvent event, int scrollSpeed, Curve animationCurve, [bool readLastDirection = true]) {
+      PointerSignalEvent event, double scrollSpeed, Curve animationCurve, [bool readLastDirection = true]) {
     // Ensure desktop physics is being used.
     if (physics == kMobilePhysics || lastLock != null) {
       if (lastLock != null) updateState = !updateState;

--- a/lib/src/scroll_state.dart
+++ b/lib/src/scroll_state.dart
@@ -14,7 +14,7 @@ class ScrollState with ChangeNotifier {
 
   ScrollState(this.mobilePhysics, this.durationMS);
 
-  void handleDesktopScroll(PointerSignalEvent event) {
+  void handleDesktopScroll(PointerSignalEvent event, int scrollSpeed) {
     // Ensure desktop physics is being used.
     if (physics == kMobilePhysics) {
       physics = kDesktopPhysics;
@@ -32,7 +32,7 @@ class ScrollState with ChangeNotifier {
           if (dy > 0) return;
         }
       }
-      futurePosition += event.scrollDelta.dy;
+      futurePosition += event.scrollDelta.dy * scrollSpeed;
 
       controller.animateTo(
         futurePosition,

--- a/lib/src/scroll_state.dart
+++ b/lib/src/scroll_state.dart
@@ -14,7 +14,8 @@ class ScrollState with ChangeNotifier {
 
   ScrollState(this.mobilePhysics, this.durationMS);
 
-  void handleDesktopScroll(PointerSignalEvent event, int scrollSpeed) {
+  void handleDesktopScroll(
+      PointerSignalEvent event, int scrollSpeed, Curve animationCurve) {
     // Ensure desktop physics is being used.
     if (physics == kMobilePhysics) {
       physics = kDesktopPhysics;
@@ -37,7 +38,7 @@ class ScrollState with ChangeNotifier {
       controller.animateTo(
         futurePosition,
         duration: Duration(milliseconds: durationMS),
-        curve: Curves.linear,
+        curve: animationCurve,
       );
     }
   }

--- a/lib/src/scroll_state.dart
+++ b/lib/src/scroll_state.dart
@@ -31,17 +31,20 @@ class ScrollState with ChangeNotifier {
       PointerSignalEvent event, int scrollSpeed, Curve animationCurve, [bool readLastDirection = true]) {
     // Ensure desktop physics is being used.
     if (physics == kMobilePhysics) {
-      physics = kDesktopPhysics;
       if (event is PointerScrollEvent) {
-        bool outOfBounds = controller.position.pixels < controller.position.minScrollExtent || controller.position.pixels > controller.position.maxScrollExtent;
-        if (!outOfBounds) controller.jumpTo(controller.position.pixels - calcMaxDelta(controller, event.scrollDelta.dy));
+        double posPixels = controller.position.pixels;
+        if ((posPixels == controller.position.minScrollExtent && event.scrollDelta.dy < 0)
+            || (posPixels == controller.position.maxScrollExtent &&  event.scrollDelta.dy > 0)) return;
+        else physics = kDesktopPhysics;
+        bool outOfBounds = posPixels < controller.position.minScrollExtent || posPixels > controller.position.maxScrollExtent;
+        if (!outOfBounds) controller.jumpTo(posPixels - calcMaxDelta(controller, event.scrollDelta.dy));
         handlePipelinedScroll = () {
           handlePipelinedScroll = null;
           if (outOfBounds) controller.jumpTo(controller.position.pixels - calcMaxDelta(controller, event.scrollDelta.dy));
           handleDesktopScroll(event, scrollSpeed, animationCurve, false);
         };
+        notifyListeners();
       }
-      notifyListeners();
       return;
     }
     if (event is PointerScrollEvent) {

--- a/lib/src/scroll_state.dart
+++ b/lib/src/scroll_state.dart
@@ -13,7 +13,6 @@ class ScrollState with ChangeNotifier {
   final int durationMS;
 
   bool prevDeltaPositive = false;
-  int prevStartingPosition = 0;
 
   ScrollState(this.mobilePhysics, this.durationMS);
 
@@ -37,12 +36,10 @@ class ScrollState with ChangeNotifier {
         }
       }
       bool currentDeltaPositive = event.scrollDelta.dy > 0;
-      int newPrevStartingPosition = futurePosition;
       if (currentDeltaPositive == prevDeltaPositive)
         futurePosition += event.scrollDelta.dy * scrollSpeed;
-      else futurePosition = prevStartingPosition + event.scrollDelta.dy * scrollSpeed;
+      else futurePosition = controller.position.pixels + event.scrollDelta.dy * scrollSpeed;
       prevDeltaPositive = event.scrollDelta.dy > 0;
-      prevStartingPosition = newPrevStartingPosition;
 
       controller.animateTo(
         futurePosition,

--- a/lib/src/scroll_state.dart
+++ b/lib/src/scroll_state.dart
@@ -12,6 +12,9 @@ class ScrollState with ChangeNotifier {
   final ScrollPhysics mobilePhysics;
   final int durationMS;
 
+  bool prevDeltaPositive = false;
+  int prevStartingPosition = 0;
+
   ScrollState(this.mobilePhysics, this.durationMS);
 
   void handleDesktopScroll(
@@ -33,7 +36,13 @@ class ScrollState with ChangeNotifier {
           if (dy > 0) return;
         }
       }
-      futurePosition += event.scrollDelta.dy * scrollSpeed;
+      bool currentDeltaPositive = event.scrollDelta.dy > 0;
+      int newPrevStartingPosition = futurePosition;
+      if (currentDeltaPositive == prevDeltaPositive)
+        futurePosition += event.scrollDelta.dy * scrollSpeed;
+      else futurePosition = prevStartingPosition + event.scrollDelta.dy * scrollSpeed;
+      prevDeltaPositive = event.scrollDelta.dy > 0;
+      prevStartingPosition = newPrevStartingPosition;
 
       controller.animateTo(
         futurePosition,

--- a/lib/src/scroll_state.dart
+++ b/lib/src/scroll_state.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'dart:math' as math;
 
 const kMobilePhysics = BouncingScrollPhysics();
 const kDesktopPhysics = NeverScrollableScrollPhysics();
 
 class ScrollState with ChangeNotifier {
   final ScrollController controller = ScrollController();
-  ScrollPhysics physics = kDesktopPhysics;
+  ScrollPhysics physics = kMobilePhysics;
   double futurePosition = 0;
 
   final ScrollPhysics mobilePhysics;
@@ -14,38 +15,51 @@ class ScrollState with ChangeNotifier {
 
   bool prevDeltaPositive = false;
 
+  Future<void>? _animationEnd;
+
+  Function()? handlePipelinedScroll;
+
   ScrollState(this.mobilePhysics, this.durationMS);
 
+  static double calcMaxDelta(ScrollController controller, double delta) {
+    return delta > 0 ? 
+      math.min(controller.position.pixels + delta, controller.position.maxScrollExtent) - controller.position.pixels :
+      math.max(controller.position.pixels + delta, controller.position.minScrollExtent) - controller.position.pixels;
+  }
+
   void handleDesktopScroll(
-      PointerSignalEvent event, int scrollSpeed, Curve animationCurve) {
+      PointerSignalEvent event, int scrollSpeed, Curve animationCurve, [bool readLastDirection = true]) {
     // Ensure desktop physics is being used.
     if (physics == kMobilePhysics) {
       physics = kDesktopPhysics;
+      if (event is PointerScrollEvent) {
+        bool outOfBounds = controller.position.pixels < controller.position.minScrollExtent || controller.position.pixels > controller.position.maxScrollExtent;
+        if (!outOfBounds) controller.jumpTo(controller.position.pixels - calcMaxDelta(controller, event.scrollDelta.dy));
+        handlePipelinedScroll = () {
+          handlePipelinedScroll = null;
+          if (outOfBounds) controller.jumpTo(controller.position.pixels - calcMaxDelta(controller, event.scrollDelta.dy));
+          handleDesktopScroll(event, scrollSpeed, animationCurve, false);
+        };
+      }
       notifyListeners();
       return;
     }
     if (event is PointerScrollEvent) {
-      // Return if limit is reached in either direction.
-      if (controller.position.atEdge) {
-        final dy = event.scrollDelta.dy;
-        // Return if bounds exceeded.
-        if (controller.position.pixels == 0) {
-          if (dy < 0) return;
-        } else {
-          if (dy > 0) return;
-        }
-      }
       bool currentDeltaPositive = event.scrollDelta.dy > 0;
-      if (currentDeltaPositive == prevDeltaPositive)
+      if (readLastDirection && currentDeltaPositive == prevDeltaPositive)
         futurePosition += event.scrollDelta.dy * scrollSpeed;
       else futurePosition = controller.position.pixels + event.scrollDelta.dy * scrollSpeed;
       prevDeltaPositive = event.scrollDelta.dy > 0;
-
-      controller.animateTo(
+      
+      Future<void> animationEnd = _animationEnd = controller.animateTo(
         futurePosition,
         duration: Duration(milliseconds: durationMS),
         curve: animationCurve,
       );
+      animationEnd.whenComplete(() {if (animationEnd == _animationEnd && physics == kDesktopPhysics) {
+        physics = mobilePhysics;
+        notifyListeners();
+      }});
     }
   }
 

--- a/lib/src/scroll_state.dart
+++ b/lib/src/scroll_state.dart
@@ -62,7 +62,7 @@ class ScrollState with ChangeNotifier {
           }
           else {
             if (lastLock != null || outOfBounds) 
-              controller.jumpTo(lastLock ?? (currPos - calcMaxDelta(controller, currDelta)));
+              controller.jumpTo(lastLock != null ? posPixels : (currPos - calcMaxDelta(controller, currDelta)));
             lastLock = null;
             handleDesktopScroll(event, scrollSpeed, animationCurve, false);
           }

--- a/lib/src/scroll_state.dart
+++ b/lib/src/scroll_state.dart
@@ -52,7 +52,6 @@ class ScrollState with ChangeNotifier {
             (currPos != controller.position.minScrollExtent || currDelta > 0));
           //bool shouldLock = lastLock != null ? (lastLock == currPos) : (currPos != posPixels);
           if (!outOfBounds && shouldLock) {
-            print("SHOULDLOCK");
             controller.jumpTo(posPixels);
             lastLock = posPixels;
             controller.position.moveTo(posPixels)..whenComplete(() {

--- a/lib/src/source.dart
+++ b/lib/src/source.dart
@@ -27,6 +27,7 @@ class DynMouseScroll extends StatelessWidget {
           final scrollState = context.read<ScrollState>();
           final controller = scrollState.controller;
           final physics = context.select((ScrollState s) => s.physics);
+          final updateState = context.select((ScrollState s) => s.updateState);
           scrollState.handlePipelinedScroll?.call();
           return Listener(
             onPointerSignal: (signalEvent) => scrollState.handleDesktopScroll(

--- a/lib/src/source.dart
+++ b/lib/src/source.dart
@@ -7,6 +7,7 @@ class DynMouseScroll extends StatelessWidget {
   final ScrollPhysics mobilePhysics;
   final int durationMS;
   final int scrollSpeed;
+  final Curve animationCurve;
   final Function(BuildContext, ScrollController, ScrollPhysics) builder;
 
   const DynMouseScroll({
@@ -14,6 +15,7 @@ class DynMouseScroll extends StatelessWidget {
     this.mobilePhysics = kMobilePhysics,
     this.durationMS = 200,
     this.scrollSpeed = 1,
+    this.animationCurve = Curves.linear,
     required this.builder,
   });
 
@@ -26,8 +28,8 @@ class DynMouseScroll extends StatelessWidget {
           final controller = scrollState.controller;
           final physics = context.select((ScrollState s) => s.physics);
           return Listener(
-            onPointerSignal: (signalEvent) =>
-                scrollState.handleDesktopScroll(signalEvent, scrollSpeed),
+            onPointerSignal: (signalEvent) => scrollState.handleDesktopScroll(
+                signalEvent, scrollSpeed, animationCurve),
             onPointerDown: scrollState.handleTouchScroll,
             child: builder(context, controller, physics),
           );

--- a/lib/src/source.dart
+++ b/lib/src/source.dart
@@ -13,9 +13,9 @@ class DynMouseScroll extends StatelessWidget {
   const DynMouseScroll({
     super.key,
     this.mobilePhysics = kMobilePhysics,
-    this.durationMS = 200,
-    this.scrollSpeed = 1,
-    this.animationCurve = Curves.linear,
+    this.durationMS = 380,
+    this.scrollSpeed = 2,
+    this.animationCurve = Curves.easeOutQuart,
     required this.builder,
   });
 

--- a/lib/src/source.dart
+++ b/lib/src/source.dart
@@ -6,12 +6,14 @@ import 'scroll_state.dart';
 class DynMouseScroll extends StatelessWidget {
   final ScrollPhysics mobilePhysics;
   final int durationMS;
+  final int scrollSpeed;
   final Function(BuildContext, ScrollController, ScrollPhysics) builder;
 
   const DynMouseScroll({
     super.key,
     this.mobilePhysics = kMobilePhysics,
     this.durationMS = 200,
+    this.scrollSpeed = 1,
     required this.builder,
   });
 
@@ -24,7 +26,8 @@ class DynMouseScroll extends StatelessWidget {
           final controller = scrollState.controller;
           final physics = context.select((ScrollState s) => s.physics);
           return Listener(
-            onPointerSignal: scrollState.handleDesktopScroll,
+            onPointerSignal: (signalEvent) =>
+                scrollState.handleDesktopScroll(signalEvent, scrollSpeed),
             onPointerDown: scrollState.handleTouchScroll,
             child: builder(context, controller, physics),
           );

--- a/lib/src/source.dart
+++ b/lib/src/source.dart
@@ -6,7 +6,7 @@ import 'scroll_state.dart';
 class DynMouseScroll extends StatelessWidget {
   final ScrollPhysics mobilePhysics;
   final int durationMS;
-  final int scrollSpeed;
+  final double scrollSpeed;
   final Curve animationCurve;
   final Function(BuildContext, ScrollController, ScrollPhysics) builder;
 

--- a/lib/src/source.dart
+++ b/lib/src/source.dart
@@ -27,6 +27,7 @@ class DynMouseScroll extends StatelessWidget {
           final scrollState = context.read<ScrollState>();
           final controller = scrollState.controller;
           final physics = context.select((ScrollState s) => s.physics);
+          scrollState.handlePipelinedScroll?.call();
           return Listener(
             onPointerSignal: (signalEvent) => scrollState.handleDesktopScroll(
                 signalEvent, scrollSpeed, animationCurve),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dyn_mouse_scroll
 description: A wrapper for scrollable widgets that enables smooth scrolling with a mouse on all platforms.
-version: 1.0.7
+version: 1.0.8
 repository: https://github.com/Bluebar1/dyn_mouse_scroll
 
 environment:


### PR DESCRIPTION
- Include Wizzel1's scroll speed commits (but changed scrollSpeed from int to double)
- When changing scroll direction, restart animation from current position instead of future position.
- Change animation curve to Curves.easeOutQuart (looks more natural), speed to 2.0 and duration to 380
- Fix trackpad gestures not working when switching between mouse wheel and trackpad
- Fix trackpad gestures not working out of the box (it used to require a click with trackpad to work)
- Detect locked scrollbar, default behaviour for scrollview not scrollable (e.g. when the mouse is hovering the scrollbar)

